### PR TITLE
Adds Mezzio Swoole Ddd Blueprint and Mastadon Examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is a curated list of projects, examples, code snippets, etc. from customers
 
 ## Examples
 * [Mezzio Swoole Ddd Blueprint](https://github.com/benjaminhirsch/mezzio-swoole-ddd-blueprint)
-* [Mastadon](https://github.com/OriPekelman/mastodon/tree/platformify)
+* [Mastodon](https://github.com/OriPekelman/mastodon/tree/platformify)
 
 ## Code Snippets
 * [NVM Cache Example](https://gist.github.com/devicezero/b38ed48bccaef72a0ab24293552992d8)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@ This is a curated list of projects, examples, code snippets, etc. from customers
 * [PostGraphile template for Platform.sh](https://github.com/platformista/postgraphile)
 * [Wiki.js for Platform.sh](https://github.com/platformista/wikijs-platformsh)
 * [CraftCMS](https://github.com/platformista/craftcms)
+
 ## Examples
+* [Mezzio Swoole Ddd Blueprint](https://github.com/benjaminhirsch/mezzio-swoole-ddd-blueprint)
+* [Mastadon](https://github.com/OriPekelman/mastodon/tree/platformify)
 
 ## Code Snippets
 * [NVM Cache Example](https://gist.github.com/devicezero/b38ed48bccaef72a0ab24293552992d8)


### PR DESCRIPTION
Adds [Mezzio Swoole Ddd Blueprint](https://github.com/benjaminhirsch/mezzio-swoole-ddd-blueprint) and [Mastadon](https://github.com/OriPekelman/mastodon/tree/platformify).

These are two that were mentioned at some point. I'm not including them as "projects" since they both appear to be PoCs of what is possible. 